### PR TITLE
Mac support refactor, compatibility, packaging

### DIFF
--- a/chrome/thunderlink/content/thunderlink.js
+++ b/chrome/thunderlink/content/thunderlink.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /*
    ThunderLink.
    Link from your browser to your email messages!
@@ -28,10 +29,6 @@ var ThunderLinkChromeNS = {
     ThunderLinkChromeNS.CopyStringToClpBrd(ThunderLinkChromeNS.GetThunderlink());
   },
 
-  GetPathToExe: function GetPathToExe() {
-    return getThunderlinkPathToExe();
-  },
-
   CopyCustomTlStringToClp: function CopyCustomTlStringToClp(cstrnum) {
     console.log("CopyCustomTlStringToClp: cstrnum: " + cstrnum + "\n");
     var prefService = Components.classes["@mozilla.org/preferences-service;1"]
@@ -42,7 +39,7 @@ var ThunderLinkChromeNS = {
     console.log("CopyCustomTlStringToClp: customTlStr: " + customTlStr + "\n");
     var tagActive = prefService.getBoolPref("custom-tl-string-" + cstrnum + "-tagcheckbox");
     console.log("CopyCustomTlStringToClp: tagActive: " + tagActive + "\n");
-    var procCustomTlStr = ThunderLinkChromeNS.ResolvePlaceholders(customTlStr);
+    var procCustomTlStr = replaceVariables(customTlStr, gDBView.hdrForFirstSelectedMessage);
     console.log("CopyCustomTlStringToClp: procCustomTlStr resolved: " + procCustomTlStr + "\n");
     procCustomTlStr = ThunderLinkChromeNS.FixNewlines(procCustomTlStr);
     console.log("CopyCustomTlStringToClp: procCustomTlStr newlines fixed: " + procCustomTlStr + "\n");
@@ -84,10 +81,6 @@ var ThunderLinkChromeNS = {
     return result;
   },
 
-  ResolvePlaceholders: function ResolvePlaceholders(tlstring) {
-    return executeThunderlinkTemplate(tlstring, gDBView.hdrForFirstSelectedMessage);
-  },
-
   GetCustomTlStringTitle: function GetCustomTlStringTitle(cstrnum) {
     var prefService = Components.classes["@mozilla.org/preferences-service;1"]
       .getService(Components.interfaces.nsIPrefService)
@@ -96,17 +89,13 @@ var ThunderLinkChromeNS = {
     return prefService.getCharPref("custom-tl-string-" + cstrnum + "-title");
   },
 
-  GetThunderlink: function GetThunderlink() {
-    return getThunderlinkForHdr(gDBView.hdrForFirstSelectedMessage);
-  },
-
   OnTlMenuLoad: function OnTlMenuLoad() {
     function createCstrMenuItem(cstrnum) {
       var label = ThunderLinkChromeNS.GetCustomTlStringTitle(cstrnum);
       // Skip when title is not configured or temporary unused
       if (!label.length || label.match(/^\./)) return null;
 
-      const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+      var XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
       var item = window.document.createElementNS(XUL_NS, "menuitem");
       item.setAttribute("label", ThunderLinkChromeNS.ConvertToUnicode(label));
       item.addEventListener("command", () => { ThunderLinkChromeNS.CopyCustomTlStringToClp(cstrnum); }, false);
@@ -139,15 +128,11 @@ var ThunderLinkChromeNS = {
   OpenThunderlinkFromClipboard: function OpenThunderlinkFromClipboard() {
     var trans = Cc["@mozilla.org/widget/transferable;1"].createInstance(Ci.nsITransferable);
     trans.init(null); trans.addDataFlavor("text/unicode");
-    Services.clipboard.getData(trans, Services.clipboard.kGlobalClipboard)
+    Services.clipboard.getData(trans, Services.clipboard.kGlobalClipboard);
     var str = {};
     var strLength = {};
     trans.getTransferData("text/unicode", str, strLength);
     var pastetext = str.value.QueryInterface(Ci.nsISupportsString).data;
     openThunderlink(pastetext);
   },
-
-  OpenMessage: function OpenMessage(mailURL) {
-    openThunderlink(mailURL);
-  }
 };

--- a/components/thunderlinkCommandLineHandler.js
+++ b/components/thunderlinkCommandLineHandler.js
@@ -10,14 +10,13 @@
    file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-const Cc = Components.classes;
-const Ci = Components.interfaces;
-const Cr = Components.results;
+var Cc = Components.classes;
+var Ci = Components.interfaces;
+var Cr = Components.results;
 
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-const MAPI_STARTUP_ARG = "MapiStartup";
-const MESSAGE_ID_PARAM = "messageid=";
+var MAPI_STARTUP_ARG = "MapiStartup";
 
 var thunderlinkCommandLineHandler = {
   get _messenger() {
@@ -39,8 +38,6 @@ var thunderlinkCommandLineHandler = {
 
     // -thunderlink <URL>
     let mailURL = null;
-    let msgHdr = null;
-    let messageID = null;
 
     try {
       mailURL = aCommandLine.handleFlagWithParam("thunderlink", false);
@@ -49,6 +46,7 @@ var thunderlinkCommandLineHandler = {
       console.error(e);
     }
 
+    // eslint-disable-next-line no-undef
     openThunderlink(mailURL);
   },
 
@@ -58,7 +56,7 @@ var thunderlinkCommandLineHandler = {
   flags: Ci.nsIClassInfo.SINGLETON,
   getHelperForLanguage: function getHelperForLanguage(languageIgnored) { },
   getInterfaces: function getInterfaces(count) {
-    const interfaces = [Ci.nsICommandLineHandler];
+    var interfaces = [Ci.nsICommandLineHandler];
     count.value = interfaces.length;
     return interfaces;
   },

--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
     <em:id>thunderlink@mozilla.org</em:id>
     <em:type>2</em:type>
     <em:name>ThunderLink</em:name>
-    <em:version>1.2.7</em:version>
+    <em:version>1.2.7-beta</em:version>
     <em:creator>Mike Hardy and Christopher Zwirello</em:creator>
     <em:description>Create clickable links to specific email messages!</em:description>
     <em:optionsURL>chrome://thunderlink/content/preferences.xul</em:optionsURL>

--- a/makeXpi.sh
+++ b/makeXpi.sh
@@ -2,7 +2,7 @@ if [ -n "$1" ]; then
     rm thunderlink-$1-tb.xpi
     perl -p -i -e "s/version>.+</version>$1</" install.rdf
     perl -p -i -e "s/\"version\"\: \".*\"/\"version\"\: \"$1\"/" manifest.json
-    zip -r thunderlink-$1-tb.xpi chrome/* manifest.json chrome.manifest components/* CREDITS defaults/* install.rdf LICENSE README.md
+    zip -r thunderlink-$1-tb.xpi chrome/* manifest.json chrome.manifest components/* CREDITS defaults/* modules/* install.rdf LICENSE README.md
 else
     echo "Please give me a version!"
 fi

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "thunderlink",
   "description": "Create clickable links to specific email messages!",
-  "version": "1.2.7",
+  "version": "1.2.7-beta",
   "author": "Mike Hardy and Christopher Zwirello",
   "homepage_url": "https://github.com/mikehardy/thunderlink",
   "legacy": {

--- a/modules/thunderlinkModule.js
+++ b/modules/thunderlinkModule.js
@@ -1,146 +1,135 @@
+// eslint-disable-next-line no-unused-vars
 var EXPORTED_SYMBOLS = [
-    "openThunderlink", 
-    "executeThunderlinkTemplate", 
-    "getThunderlinkPathToExe", 
-    "getThunderlinkForHdr"
+  "openThunderlink",
+  "replaceVariables",
+  "getThunderlinkPathToExe",
+  "getThunderlinkForHdr",
 ];
 
-const MESSAGE_ID_PARAM = "messageid=";
+var MESSAGE_ID_PARAM = "messageid=";
 
-ChromeUtils.import("resource:///modules/MailUtils.js");
-ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
+Components.utils.import("resource:///modules/MailUtils.js");
+Components.utils.import("resource:///modules/iteratorUtils.jsm");
 
-function openThunderlink(mailURL) {
-    if (mailURL && mailURL.length > 0) {
-        let msgHdr = null;
-        if (/^thunderlink:\/\//.test(mailURL)) {
-          // This might be a standard message URI, or one with a messageID
-          // parameter. Handle both cases.
-          let messageIDIndex = mailURL.toLowerCase().indexOf(MESSAGE_ID_PARAM);
-          if (messageIDIndex != -1) {
-            // messageID parameter
-            // Convert the message URI into a folder URI
-            let folderURI = mailURL.slice(0, messageIDIndex)
-                                 .replace("thunderlink", "mailbox");
-            // Get the message ID
-            let messageID = mailURL.slice(messageIDIndex + MESSAGE_ID_PARAM.length);
-  
-            // if on Windows, there will be an added trailing slash 
-            // which we remove
-            if (/\/$/.test(messageID)) {
-              messageID = messageID.slice(0,messageID.length-1);
-            }          
-  
-            // Make sure the folder tree is initialized
-            MailUtils.discoverFolders();
-  
-            let folder = MailUtils.getFolderForURI(folderURI, true);
-            // The folder might not exist, so guard against that
-            //if (folder && messageID.length > 0)
-            //  msgHdr = folder.msgDatabase.getMsgHdrForMessageID(messageID);
-  
-            // No message in this folder? Search through all folders:
-            if (msgHdr === null){
-              let accountManager = Cc["@mozilla.org/messenger/account-manager;1"]
-                        .getService(Ci.nsIMsgAccountManager);
-              let folders = accountManager.allFolders;
-              let tmpHdr = null;
-              let foldersArray = fixIterator(folders.enumerate(), Ci.nsIMsgFolder)
-              console.log("foldersArray: ", foldersArray);
-              for (let msgFolder of foldersArray) {
-                if(msgHdr !== null) {
-                  break;
-                }
-                try {
-                  msgHdr = msgFolder.msgDatabase.getMsgHdrForMessageID(messageID);
-                } catch(e) {
-                  Components.utils.reportError("caught exception while accessing folder " + msgFolder.folderURL + ":\n"+e);
-                }
-              };
-            }           
-          }
-        }
-        
-        if (msgHdr) {
-            let wm = Cc["@mozilla.org/appshell/window-mediator;1"].
-                getService(Ci.nsIWindowMediator);
-            let win = wm.getMostRecentWindow("mail:3pane");
-            let openTl = getPref("open-tl-behaviour");
-
-            if('openInNewWindow' == openTl){
-                MailUtils.openMessagesInNewWindows([msgHdr]);
-            } else if ('openInNewTab' == openTl) {
-                MailUtils.displayMessage(msgHdr);	
-            } else {//select in 3pane window
-                if (win) {
-                    var tabmail = win.document.getElementById("tabmail");
-                    tabmail.switchToTab(0)//will always be the mail tab
-                    win.focus();
-                    win.gFolderTreeView.selectFolder(msgHdr.folder);
-                    win.gFolderDisplay.selectMessage(msgHdr);
-                    //console.log("thunderlinkCommandLineHandler_handle: selecting " + msgHdr + "\n");
-                } else {
-                    MailUtils.displayMessage(msgHdr);
-                }
-            }
-        } else {
-          //console.log("Unrecognized ThunderLink URL: " + mailURL + "\n");
-          var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
-            .getService(Components.interfaces.nsIPromptService);
-          promptService.alert(null, "Message not found", "Couldn't find an email message for ThunderLink\n\n" + mailURL);
-          //Components.utils.reportError("Couldn't find an email message for ThunderLink\n\n" + mailURL);
-        }
-    }
-}
-  
 function getPref(prefName) {
-    var prefService = Components.classes["@mozilla.org/preferences-service;1"]
-        .getService(Components.interfaces.nsIPrefService)
-        .getBranch("extensions.thunderlink.");
-    
-    return prefService.getCharPref(prefName);		
-}  
+  var prefService = Components.classes["@mozilla.org/preferences-service;1"]
+    .getService(Components.interfaces.nsIPrefService)
+    .getBranch("extensions.thunderlink.");
 
-function executeThunderlinkTemplate(template, hdr) {
-    Components.utils.import("resource:///modules/gloda/utils.js");
-    var subject = GlodaUtils.deMime(hdr.subject);
-
-    // replace a few characters that frequently cause trouble
-    // with a focus on org-mode, provided as filteredSubject
-    var protectedSubject = subject.split("[").join("(");
-    protectedSubject = protectedSubject.split("]").join(")");
-    protectedSubject = protectedSubject.replace(/[<>'"`´]/g, "");
-
-    var result = template.replace(/<thunderlink>/ig, getThunderlinkForHdr(hdr));
-    result = result.replace(/<messageid>/ig, hdr.messageId);
-    result = result.replace(/<subject>/ig, subject);
-    result = result.replace(/<filteredSubject>/ig, protectedSubject);
-    result = result.replace(/<sender>/ig, hdr.author);
-    result = result.replace(/<tbexe>/ig, "\"" + getThunderlinkPathToExe() + "\" -thunderlink ");
-
-    var date = new Date(hdr.date/1000);
-    var dateString = date.toLocaleDateString() + " - " + date.toLocaleTimeString();   
-    result = result.replace(/<time>/ig, dateString);            
-
-    return result;
+  return prefService.getCharPref(prefName);
 }
 
-function   getThunderlinkForHdr(hdr) {
-    return "thunderlink://messageid=" + hdr.messageId;
+function getThunderlinkForHdr(hdr) {
+  return "thunderlink://messageid=" + hdr.messageId;
 }
 
 function getThunderlinkPathToExe() {
-    var appDir;
-    try {
-        appDir = Components.classes["@mozilla.org/file/directory_service;1"]
-            .getService(Components.interfaces.nsIProperties)
-            .get("CurProcD", Components.interfaces.nsIFile);
-    } catch (ex) {
-        console.error(ex);
-    }
-    // gives an [xpconnect wrapped nsILocalFile]
-    appDir.append("thunderbird"); // exe filename
-    return appDir.path;
+  var appDir;
+  try {
+    appDir = Components.classes["@mozilla.org/file/directory_service;1"]
+      .getService(Components.interfaces.nsIProperties)
+      .get("CurProcD", Components.interfaces.nsIFile);
+  } catch (ex) {
+    console.error(ex);
+  }
+  // gives an [xpconnect wrapped nsILocalFile]
+  appDir.append("thunderbird"); // exe filename
+  return appDir.path;
 }
 
+// eslint-disable-next-line no-unused-vars
+function openThunderlink(mailURL) {
+  if (mailURL && mailURL.length > 0) {
+    let msgHdr = null;
+    if (/^thunderlink:\/\//.test(mailURL)) {
+      // This might be a standard message URI, or one with a messageID
+      // parameter. Handle both cases.
+      var messageIDIndex = mailURL.toLowerCase().indexOf(MESSAGE_ID_PARAM);
+      if (messageIDIndex !== -1) {
+        // messageID parameter
+        let messageID = mailURL.slice(messageIDIndex + MESSAGE_ID_PARAM.length);
 
+        // if on Windows, there will be an added trailing slash
+        // which we remove
+        if (/\/$/.test(messageID)) {
+          messageID = messageID.slice(0, messageID.length - 1);
+        }
+
+        // Make sure the folder tree is initialized
+        MailUtils.discoverFolders();
+
+        // No message in this folder? Search through all folders:
+        if (msgHdr === null) {
+          var accountManager = Components.classes["@mozilla.org/messenger/account-manager;1"]
+            .getService(Components.interfaces.nsIMsgAccountManager);
+          var folders = accountManager.allFolders;
+          var foldersArray = fixIterator(folders.enumerate(), Components.interfaces.nsIMsgFolder);
+          // console.log("foldersArray: ", foldersArray);
+          // eslint-disable-next-line no-restricted-syntax
+          for (var msgFolder of foldersArray) {
+            if (msgHdr !== null) {
+              break;
+            }
+            try {
+              msgHdr = msgFolder.msgDatabase.getMsgHdrForMessageID(messageID);
+            } catch (e) {
+              Components.utils.reportError("caught exception while accessing folder " + msgFolder.folderURL + ":\n" + e);
+            }
+          }
+        }
+      }
+    }
+
+    if (msgHdr) {
+      var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator);
+      var win = wm.getMostRecentWindow("mail:3pane");
+      var openTl = getPref("open-tl-behaviour");
+
+      if (openTl === 'openInNewWindow') {
+        MailUtils.openMessagesInNewWindows([msgHdr]);
+      } else if (openTl === 'openInNewTab') {
+        MailUtils.displayMessage(msgHdr);
+      } else if (win) {
+        // select in 3pane window
+        var tabmail = win.document.getElementById("tabmail");
+        tabmail.switchToTab(0); // will always be the mail tab
+        win.focus();
+        win.gFolderTreeView.selectFolder(msgHdr.folder);
+        win.gFolderDisplay.selectMessage(msgHdr);
+        // console.log("thunderlinkCommandLineHandler_handle: selecting " + msgHdr + "\n");
+      } else {
+        MailUtils.displayMessage(msgHdr);
+      }
+    } else {
+      // console.log("Unrecognized ThunderLink URL: " + mailURL + "\n");
+      var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
+        .getService(Components.interfaces.nsIPromptService);
+      promptService.alert(null, "Message not found", "Couldn't find an email message for ThunderLink\n\n" + mailURL);
+    }
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+function replaceVariables(template, hdr) {
+  Components.utils.import("resource:///modules/gloda/utils.js");
+  var subject = GlodaUtils.deMime(hdr.subject);
+
+  // replace a few characters that frequently cause trouble
+  // with a focus on org-mode, provided as filteredSubject
+  var protectedSubject = subject.split("[").join("(");
+  protectedSubject = protectedSubject.split("]").join(")");
+  protectedSubject = protectedSubject.replace(/[<>'"`´]/g, "");
+
+  var result = template.replace(/<thunderlink>/ig, getThunderlinkForHdr(hdr));
+  result = result.replace(/<messageid>/ig, hdr.messageId);
+  result = result.replace(/<subject>/ig, subject);
+  result = result.replace(/<filteredSubject>/ig, protectedSubject);
+  result = result.replace(/<sender>/ig, hdr.author);
+  result = result.replace(/<tbexe>/ig, "\"" + getThunderlinkPathToExe() + "\" -thunderlink ");
+
+  var date = new Date(hdr.date / 1000);
+  var dateString = date.toLocaleDateString() + " - " + date.toLocaleTimeString();
+  result = result.replace(/<time>/ig, dateString);
+
+  return result;
+}


### PR DESCRIPTION
@MarioKusek  See if these changes work for you - some were fundamental (including the module in the XPI), some where compatibility you wouldn't have checked (not using ChromeUtils, maybe the Cc / Ci names, use of 'const' etc - for TB38) and some was style (I use Visual Studio Code with the eslint plugin as a code standard)

I also just called into the ThunderlinkModule directory for function calls, I didn't see a reason to wrap them in content/thunderlink.js?

They all seem to work for me now on TB38, TB60.2 and TB64.0b4 - if they work for you, you can merge this into your branch, it should show up in the PR, then I can mash it into master on my fork?